### PR TITLE
Handle single names better

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to your bashrc. (Sourcing the script allows it to change directory.)
 
 ```bash
 ghd <repo_name or repo url (with https://github.com or git@github.com:)>
-ghd <already cloned user or organization>
+ghd <already cloned user, org, or repo name>
 ghd /
 ghd
 ```

--- a/ghd
+++ b/ghd
@@ -4,7 +4,7 @@
 #
 # Switches to the given github url/repo.
 # Clones to GHD_LOCATION, or /tmp/ghd if not set.
-# Clones via the given schema, or https by default (set GHD_USE_SSH=1 for ssh).
+# Clones via https by default (set GHD_USE_SSH=1 for ssh).
 
 function _ghd_run() {
   location_root="${GHD_LOCATION:-/tmp/ghd}"
@@ -33,10 +33,11 @@ function _ghd_run() {
     fi
   }
 
-  function fzf_ghd() {
+  function fzf_ghd() { # query
+    query="$1"
     if declare -F __fzfcmd >/dev/null; then
       dest="$(find $location_root -maxdepth 2 -printf "%P\n" | \
-        $(__fzfcmd) --preview="
+        $(__fzfcmd) --query="$query" --preview="
           printf 'https://www.github.com/{}\n\n' &&
           $pager '$location_root/{}/README.md'" \
       )"
@@ -50,6 +51,32 @@ function _ghd_run() {
     fi
   }
 
+  function handle_single_name() { # name
+    single_name="$1"
+    matches="$(find $location_root -maxdepth 2 -name "$single_name")"
+    if [[ -z $matches ]]; then
+      if fzf_ghd "$single_name"; then
+        return 0
+      fi
+      echo "No cloned repository, user, or organization found for: $single_name"
+      return 1
+    fi
+
+    num_matches="$(echo "$matches" | wc -l)"
+    if [ "$num_matches" -eq 1 ]; then
+      cd "$matches"
+      return 0
+    fi
+
+    if fzf_ghd "$single_name"; then
+      return 0
+    fi
+
+    echo "Found multiple matches for $single_name:"
+    echo "$matches"
+    return 1
+  }
+
   mkdir -p "$location_root"
 
   if [[ -z "$repo_url_or_name" ]]; then
@@ -61,10 +88,12 @@ function _ghd_run() {
     fi
   fi
 
-  # Otherwise, go to the repo's directory (cloning if necessary).
   repo_name="$(get_repo_name "$repo_url_or_name")"
   repo_url="$(get_repo_url "$repo_url_or_name")"
-  if [[ ! -d "$location_root/$repo_name" ]]; then
+  if [[ "$repo_name" != *"/"* ]]; then
+    handle_single_name $repo_name
+    return $?
+  elif [[ ! -d "$location_root/$repo_name" ]]; then
     git clone -- "$repo_url" "$location_root/$repo_name"
     if [[ $? != 0 ]]; then
       return 1 # If git clone fails, exit.


### PR DESCRIPTION
If it's ambiguous, give fzf choice.
If it's not ambiguous repo, org, etc - switch to that.
If there's nothing, say so.